### PR TITLE
Switch from stacktrace-parser to error-stack-parser

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ Retrace.prototype.mapFrame = function(f) {
     return sm.originalPositionFor({
       source: f.fileName,
       line: f.lineNumber,
-      column: f.column
+      column: f.columnNumber
     });
   });
 };

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var dataUriToBuffer = require('data-uri-to-buffer');
 var got = require('got');
-var parser = require('stacktrace-parser');
+var parser = require('error-stack-parser');
 var Promise = require('promise');
 var SourceMapConsumer = require('source-map').SourceMapConsumer;
 var url = require('url');
@@ -17,8 +17,11 @@ function Retrace() {
 }
 
 Retrace.prototype.map = function(stack) {
-  return Promise.all(parser.parse(stack).map(this.mapFrame, this))
-  .then(function(frames) {
+  return Promise.all(
+    parser
+      .parse({stack: stack})
+      .map(this.mapFrame, this)
+  ).then(function(frames) {
     var msg = /^.*$/m.exec(stack)[0];
     return msg + '\n' + frames.map(function(f) {
       var pos = f.source;
@@ -31,9 +34,9 @@ Retrace.prototype.map = function(stack) {
 };
 
 Retrace.prototype.mapFrame = function(f) {
-  return this.getSourceMapConsumer(f.file).then(function(sm) {
+  return this.getSourceMapConsumer(f.fileName).then(function(sm) {
     return sm.originalPositionFor({
-      source: f.file,
+      source: f.fileName,
       line: f.lineNumber,
       column: f.column
     });

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
   "license": "MIT",
   "dependencies": {
     "data-uri-to-buffer": "0.0.4",
+    "error-stack-parser": "^2.0.1",
     "got": "^5.1.0",
     "promise": "^7.0.4",
-    "source-map": "^0.5.3",
-    "stacktrace-parser": "^0.1.3"
+    "source-map": "^0.5.3"
   },
   "devDependencies": {
     "browserify": "^12.0.1",


### PR DESCRIPTION
Was having issues with stacktraces from firefox parsed by stacktrace-parser that had forward slashes in them, e.g.,

```
NotAuthenticated: No auth token
    r@http://127.0.0.1:3000/vendor-cfbf8b8.js:11:60691
    i@http://127.0.0.1:3000/vendor-cfbf8b8.js:11:60788
    _@http://127.0.0.1:3000/vendor-cfbf8b8.js:11:61834
    value/</<@http://127.0.0.1:3000/vendor-cfbf8b8.js:38:96281
```

would become:

```
NotAuthenticated: No auth token
    at webpack:///node_modules/feathers-errors/lib/index.js:70:17
    at FeathersError(webpack:///node_modules/feathers-errors/lib/index.js:100:2)
    at webpack:///node_modules/feathers-errors/lib/index.js:245:31
```

(Notice the last line is missing).