### PR TITLE
Fix identity

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ Retrace.prototype.mapFrame = function(f) {
 Retrace.prototype.register = function(uri, sourceMap) {
   return this.consumers[uri] = Promise.resolve(sourceMap).then(function(sm) {
     if (typeof sm == 'string') sm = JSON.parse(sm);
-    if (!sm) sm = identity;
+    if (!sm) return identity;
     return new SourceMapConsumer(sm);
   });
 }

--- a/index.js
+++ b/index.js
@@ -32,11 +32,13 @@ Retrace.prototype.map = function(stack) {
 
 Retrace.prototype.mapFrame = function(f) {
   return this.getSourceMapConsumer(f.fileName).then(function(sm) {
-    return sm.originalPositionFor({
+    var m = sm.originalPositionFor({
       source: f.fileName,
       line: f.lineNumber,
       column: f.columnNumber
     });
+    if(!m.name) m.name = f.functionName;
+    return m;
   });
 };
 


### PR DESCRIPTION
When a source map promise fails to resolve, the identity source map is installed incorrectly, leading to an error about missing fields from source-map module.

Also pass-through function names from original stack trace if identity map is being used.